### PR TITLE
fixes: git changelog & nvim-setup

### DIFF
--- a/install/bin.yml
+++ b/install/bin.yml
@@ -8,6 +8,6 @@
 - clean: ['~']
 
 - link:
-    ~/.bin/git-changelog: bin/git-changelog
+    ~/.bin/git-summary: bin/git-summary
     ~/.bin/git-commits-since: bin/git-commits-since
     ~/.bin/transliterate: bin/transliterate


### PR DESCRIPTION
This PR will:
- bump `nvim-setup` reference
- replace symlink `bin/git-changelog` with `bin/git-summary` 