### PR TITLE
feat: show Ghostty tabs in titlebar

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -13,6 +13,7 @@ background-blur-radius = 20
 window-padding-x = 10
 window-padding-y = 8
 window-save-state = always
+macos-titlebar-style = tabs
 
 # Cursor and mouse
 cursor-style = bar


### PR DESCRIPTION
## Summary
- use Ghostty’s native macOS tabs titlebar
- retain the existing native and custom tab/window shortcuts

## Validation
- `ghostty +validate-config --config-file=.config/ghostty/config`
- `git diff --check`